### PR TITLE
feat: load recent observations on web console page load

### DIFF
--- a/assets/viewer/index.html
+++ b/assets/viewer/index.html
@@ -50,6 +50,40 @@
     const statusEl = document.getElementById('status');
     let hasEvents = false;
 
+    function clearPlaceholder() {
+      if (!hasEvents) {
+        eventsEl.innerHTML = '';
+        hasEvents = true;
+      }
+    }
+
+    function createEventCard(data, timestamp) {
+      const div = document.createElement('div');
+      div.className = 'event';
+      div.innerHTML = `
+        <div class="type">${escHtml(data.type || 'observation')}</div>
+        <div class="title">${escHtml(data.title || '')}</div>
+        <div class="time">${timestamp}</div>
+      `;
+      return div;
+    }
+
+    async function loadRecent() {
+      try {
+        const resp = await fetch('/api/observations/recent?limit=50');
+        if (!resp.ok) return;
+        const observations = await resp.json();
+        if (!observations || observations.length === 0) return;
+        clearPlaceholder();
+        for (const obs of observations) {
+          const time = obs.CreatedAt ? new Date(obs.CreatedAt).toLocaleString() : '';
+          eventsEl.appendChild(createEventCard(obs, time));
+        }
+      } catch (err) {
+        console.error('Load recent error:', err);
+      }
+    }
+
     function connect() {
       const es = new EventSource('/api/events');
       es.onopen = () => { statusEl.textContent = 'Connected'; };
@@ -57,20 +91,10 @@
         statusEl.textContent = 'Disconnected — retrying...';
       };
       es.addEventListener('observation', (e) => {
-        if (!hasEvents) {
-          eventsEl.innerHTML = '';
-          hasEvents = true;
-        }
+        clearPlaceholder();
         try {
           const data = JSON.parse(e.data);
-          const div = document.createElement('div');
-          div.className = 'event';
-          div.innerHTML = `
-            <div class="type">${escHtml(data.type || 'observation')}</div>
-            <div class="title">${escHtml(data.title || '')}</div>
-            <div class="time">${new Date().toLocaleTimeString()}</div>
-          `;
-          eventsEl.prepend(div);
+          eventsEl.prepend(createEventCard(data, new Date().toLocaleTimeString()));
         } catch (err) {
           console.error('Parse event error:', err);
         }
@@ -83,6 +107,7 @@
       return d.innerHTML;
     }
 
+    loadRecent();
     connect();
   </script>
 </body>

--- a/internal/console/handlers.go
+++ b/internal/console/handlers.go
@@ -68,6 +68,19 @@ func (s *Server) handleGetObservation(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, obs)
 }
 
+func (s *Server) handleRecentObservations(w http.ResponseWriter, r *http.Request) {
+	limit := int(parseID(r.URL.Query().Get("limit")))
+	project := r.URL.Query().Get("project")
+
+	results, err := s.db.RecentObservations(project, limit)
+	if err != nil {
+		s.logger.Error("recent observations", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, results)
+}
+
 func (s *Server) handleSearchObservations(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("q")
 	if query == "" {

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -112,6 +112,7 @@ func (s *Server) registerRoutes() {
 		r.Get("/events", s.handleSSE)
 
 		r.Post("/observations", s.handleCreateObservation)
+		r.Get("/observations/recent", s.handleRecentObservations)
 		r.Get("/observations/{id}", s.handleGetObservation)
 		r.Get("/observations/search", s.handleSearchObservations)
 		r.Get("/observations/hybrid-search", s.handleHybridSearch)


### PR DESCRIPTION
## Summary

- Adds `GET /api/observations/recent` endpoint (with optional `?limit=` and `?project=` params) that exposes the existing `db.RecentObservations()` method over HTTP
- Updates the web viewer to fetch recent observations on page load so the console shows data immediately instead of "Waiting for observations..."
- New SSE observations continue to be prepended at the top of the list

Closes #1

## Test plan

- [x] `TestRecentObservations` covers empty DB, default fetch, limit param, and project filter
- [x] Full test suite passes (`make test`)
- [x] Binary builds (`make build`)
- [ ] Manual: open `http://localhost:41777` with existing observations in DB — they should render on load
- [ ] Manual: verify new SSE observations still prepend at the top