### PR TITLE
fix: align release binary names and Homebrew dispatch event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,10 +102,10 @@ jobs:
         with:
           tag_name: ${{ steps.bump.outputs.new_tag }}
           files: |
-            bin/icc-darwin-arm64
-            bin/icc-darwin-amd64
-            bin/icc-linux-arm64
-            bin/icc-linux-amd64
+            bin/itkdev-claude-code-darwin-arm64
+            bin/itkdev-claude-code-darwin-amd64
+            bin/itkdev-claude-code-linux-arm64
+            bin/itkdev-claude-code-linux-amd64
           generate_release_notes: true
 
       - name: Update Homebrew formula
@@ -119,4 +119,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token $HOMEBREW_TAP_TOKEN" \
             https://api.github.com/repos/yepzdk/homebrew-tools/dispatches \
-            -d "{\"event_type\":\"update-icc\",\"client_payload\":{\"version\":\"$VERSION\"}}"
+            -d "{\"event_type\":\"update-itkdev-claude-code\",\"client_payload\":{\"version\":\"$VERSION\"}}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BINARY_NAME ?= icc
+BINARY_NAME ?= itkdev-claude-code
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-X github.com/itk-dev/itkdev-claude-code/internal/config.version=$(VERSION)"
 


### PR DESCRIPTION
## Summary

- Changes `BINARY_NAME` in Makefile from `icc` to `itkdev-claude-code` so release artifacts are named `itkdev-claude-code-darwin-arm64` etc., matching what the Homebrew tap expects
- Updates the release workflow dispatch event type from `update-icc` to `update-itkdev-claude-code`
- Updates the release workflow file list to reference the new binary names

## Test plan

- [x] `make build` produces `bin/itkdev-claude-code`
- [x] Full test suite passes
- [ ] Next release should produce correctly named binaries and trigger Homebrew tap update