### PR TITLE
feat: add preflight dependency checking and capability discovery

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/itk-dev/itkdev-claude-code/internal/session"
+	"github.com/spf13/cobra"
+)
+
+// errMissingDeps is returned by the check command when required dependencies are missing.
+var errMissingDeps = fmt.Errorf("required dependencies missing")
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check dependency status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		// Create logger for preflight check (debug level for standalone command)
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		results := session.PreflightCheck(logger)
+
+		if jsonOutput {
+			if err := json.NewEncoder(out).Encode(results); err != nil {
+				return err
+			}
+			// Check for missing deps even in JSON mode
+			for _, r := range results {
+				if r.Status == session.StatusMissing {
+					return errMissingDeps
+				}
+			}
+			return nil
+		}
+
+		// Human-readable output
+		fmt.Fprintln(out, "Dependency Check:")
+
+		// Track if any required deps are missing for exit code
+		hasMissing := false
+
+		const statusWidth = 10
+		const nameWidth = 20
+
+		for _, r := range results {
+			// Map status to display label
+			displayStatus := r.Status
+			if r.Status == session.StatusMissing {
+				displayStatus = "MISSING"
+				hasMissing = true
+			}
+
+			// Pad status to fixed width
+			paddedStatus := fmt.Sprintf("%-*s", statusWidth, displayStatus)
+
+			// Calculate dots needed for alignment
+			dotsNeeded := nameWidth - len(r.Name)
+			if dotsNeeded < 2 {
+				dotsNeeded = 2
+			}
+			dots := " " + strings.Repeat(".", dotsNeeded-1)
+
+			fmt.Fprintf(out, "  %s%s%s %s\n", paddedStatus, r.Name, dots, r.Message)
+		}
+
+		if hasMissing {
+			return errMissingDeps
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(checkCmd)
+}

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/itk-dev/itkdev-claude-code/internal/session"
+)
+
+func TestCheckCommand(t *testing.T) {
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = false })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"check"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("check command failed: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify output contains expected header
+	if !strings.Contains(output, "Dependency Check:") {
+		t.Error("output missing 'Dependency Check:' header")
+	}
+
+	// Verify output contains some dependency names
+	if len(output) < 20 {
+		t.Error("output is too short, expected dependency results")
+	}
+}
+
+func TestCheckCommandJSON(t *testing.T) {
+	t.Cleanup(func() { jsonOutput = false })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"check", "--json"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("check --json command failed: %v", err)
+	}
+
+	var results []session.CheckResult
+	if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+
+	if len(results) == 0 {
+		t.Error("expected results, got empty array")
+	}
+
+	// Verify result structure
+	for _, r := range results {
+		if r.Name == "" {
+			t.Error("result has empty Name field")
+		}
+		if r.Status == "" {
+			t.Error("result has empty Status field")
+		}
+	}
+}
+
+func TestCheckCommand_MissingDepsReturnError(t *testing.T) {
+	jsonOutput = false
+	t.Cleanup(func() { jsonOutput = false })
+
+	// Set PATH to empty dir so required deps are missing
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"check"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for missing required dependencies, got nil")
+	}
+}

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -93,6 +93,7 @@ func buildInfo() InfoData {
 			{"icc install", "Set up project configuration"},
 			{"icc serve", "Standalone console server"},
 			{"icc info", "Show this capabilities reference"},
+			{"icc check", "Check dependency status"},
 			{"icc greet", "Print the welcome banner"},
 			{"icc worktree", "Git worktree management"},
 			{"icc session list", "List sessions"},

--- a/internal/console/mcp.go
+++ b/internal/console/mcp.go
@@ -159,6 +159,10 @@ func (s *Server) handleMCPSaveMemory(_ context.Context, req mcp.CallToolRequest)
 		return mcpError(fmt.Sprintf("save_memory failed: %v", err)), nil
 	}
 
+	// Broadcast to SSE subscribers
+	eventData, _ := json.Marshal(map[string]any{"id": id, "type": "discovery", "title": title})
+	s.sse.Send(Event{Type: "observation", Data: string(eventData)})
+
 	return mcpJSON(map[string]int64{"id": id})
 }
 

--- a/internal/session/preflight.go
+++ b/internal/session/preflight.go
@@ -1,0 +1,95 @@
+package session
+
+import (
+	"fmt"
+	"log/slog"
+	"os/exec"
+
+	"github.com/itk-dev/itkdev-claude-code/internal/config"
+)
+
+// Status constants for CheckResult.
+const (
+	StatusOK      = "ok"
+	StatusMissing = "missing"
+	StatusWarning = "warning"
+)
+
+// CheckResult represents the result of checking a single dependency.
+type CheckResult struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"` // StatusOK, StatusMissing, or StatusWarning
+	Message string `json:"message"`
+}
+
+// PreflightCheck validates that required and optional dependencies are available.
+// It checks required binaries (git, claude), optional binaries (npx, vexor,
+// playwright-cli, mcp-cli), and optional plugins via config.MissingPlugins().
+//
+// The function returns a slice of CheckResult — one for each dependency checked.
+// The caller is responsible for formatting and outputting the results.
+//
+// Optional binary list mirrors the installer's npm packages in installer/steps/dependencies.go.
+// Keep these lists in sync when adding or removing optional dependencies.
+func PreflightCheck(logger *slog.Logger) []CheckResult {
+	var results []CheckResult
+
+	// Check required binaries
+	requiredBinaries := []string{"git", "claude"}
+	for _, bin := range requiredBinaries {
+		logger.Debug("checking binary", "name", bin, "required", true)
+		_, err := exec.LookPath(bin)
+		if err != nil {
+			results = append(results, CheckResult{
+				Name:    bin,
+				Status:  StatusMissing,
+				Message: "not found in PATH",
+			})
+		} else {
+			results = append(results, CheckResult{
+				Name:    bin,
+				Status:  StatusOK,
+				Message: "found",
+			})
+		}
+	}
+
+	// Check optional binaries (npm globals and npx)
+	// These match the packages in installer/steps/dependencies.go
+	optionalBinaries := []string{"npx", "vexor", "playwright-cli", "mcp-cli"}
+	for _, bin := range optionalBinaries {
+		logger.Debug("checking binary", "name", bin, "required", false)
+		_, err := exec.LookPath(bin)
+		if err != nil {
+			results = append(results, CheckResult{
+				Name:    bin,
+				Status:  StatusWarning,
+				Message: "not found (optional)",
+			})
+		} else {
+			results = append(results, CheckResult{
+				Name:    bin,
+				Status:  StatusOK,
+				Message: "found",
+			})
+		}
+	}
+
+	// Check plugins
+	missing, err := config.MissingPlugins()
+	if err != nil {
+		logger.Debug("could not check plugins", "error", err)
+		// Gracefully skip plugin checking on error (matches existing checkRequiredPlugins behavior)
+	} else {
+		for _, req := range missing {
+			results = append(results, CheckResult{
+				Name:   req.Name,
+				Status: StatusWarning,
+				Message: fmt.Sprintf("not installed — install with: /plugin marketplace add itk-dev/itkdev-claude-plugins && /plugin install %s@%s",
+					req.Name, req.Marketplace),
+			})
+		}
+	}
+
+	return results
+}

--- a/internal/session/preflight_test.go
+++ b/internal/session/preflight_test.go
@@ -1,0 +1,144 @@
+package session
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testLogger returns a logger that discards output to keep test output clean.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestPreflightCheck(t *testing.T) {
+	// Create a temporary directory to use as PATH
+	tmpDir := t.TempDir()
+
+	// Create dummy git and claude binaries for testing
+	for _, name := range []string{"git", "claude"} {
+		path := filepath.Join(tmpDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Set PATH to only include our temp directory
+	t.Setenv("PATH", tmpDir)
+
+	results := PreflightCheck(testLogger())
+
+	// Verify results structure
+	if len(results) == 0 {
+		t.Fatal("expected results, got empty slice")
+	}
+
+	// Check for git and claude (should be "ok")
+	for _, name := range []string{"git", "claude"} {
+		found := false
+		for _, r := range results {
+			if r.Name == name {
+				found = true
+				if r.Status != StatusOK {
+					t.Errorf("%s status = %q, want %q", name, r.Status, StatusOK)
+				}
+				if r.Message != "found" {
+					t.Errorf("%s message = %q, want %q", name, r.Message, "found")
+				}
+			}
+		}
+		if !found {
+			t.Errorf("%s not found in results", name)
+		}
+	}
+}
+
+func TestPreflightCheck_MissingRequired(t *testing.T) {
+	// Set PATH to empty directory so binaries are not found
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir)
+
+	results := PreflightCheck(testLogger())
+
+	// Check that git and claude have "missing" status
+	for _, name := range []string{"git", "claude"} {
+		found := false
+		for _, r := range results {
+			if r.Name == name && r.Status == StatusMissing {
+				found = true
+				if r.Message == "" {
+					t.Errorf("%s missing message is empty", name)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("%s missing status not found in results", name)
+		}
+	}
+}
+
+func TestPreflightCheck_OptionalWarning(t *testing.T) {
+	// Create temp dir with only required binaries
+	tmpDir := t.TempDir()
+	for _, name := range []string{"git", "claude"} {
+		path := filepath.Join(tmpDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("PATH", tmpDir)
+
+	results := PreflightCheck(testLogger())
+
+	// All four optional binaries should have "warning" status
+	expectedOptional := []string{"npx", "vexor", "playwright-cli", "mcp-cli"}
+	for _, name := range expectedOptional {
+		found := false
+		for _, r := range results {
+			if r.Name == name {
+				found = true
+				if r.Status != StatusWarning {
+					t.Errorf("%s status = %q, want %q", name, r.Status, StatusWarning)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("optional binary %q not found in results", name)
+		}
+	}
+}
+
+func TestCheckResult_JSONSerialization(t *testing.T) {
+	result := CheckResult{
+		Name:    "test-dep",
+		Status:  StatusOK,
+		Message: "found",
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	jsonStr := string(data)
+
+	// Verify JSON tags produce correct key names
+	for _, key := range []string{`"name"`, `"status"`, `"message"`} {
+		if !strings.Contains(jsonStr, key) {
+			t.Errorf("JSON output missing key %s: %s", key, jsonStr)
+		}
+	}
+
+	// Verify values are present
+	if !strings.Contains(jsonStr, `"test-dep"`) {
+		t.Errorf("JSON output missing name value: %s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"ok"`) {
+		t.Errorf("JSON output missing status value: %s", jsonStr)
+	}
+}


### PR DESCRIPTION
## Summary

- **Preflight dependency checking** (`icc check` + startup validation) — Closes #12
- **Capability discovery** (`icc info` command, session context, tips) — Closes #15
- **Console improvements** (SSE heartbeat, MCP broadcast for live feed)

## Changes

### Preflight Dependency Checking (#12)
- Add `PreflightCheck(logger)` function in `internal/session/preflight.go` with `CheckResult` type and status constants (`StatusOK`, `StatusMissing`, `StatusWarning`)
- Check required binaries (git, claude), optional binaries (npx, vexor, playwright-cli, mcp-cli), and plugins via `config.MissingPlugins()`
- Integrate into `icc run` startup: aggregate all missing required deps into single error, warn on optional deps via stderr
- Remove old `checkRequiredPlugins` function (subsumed by preflight)
- Add `icc check` CLI command with human-readable table and `--json` output, exit code 1 when required deps missing
- Comprehensive tests with PATH manipulation for deterministic results

### Capability Discovery (#15)
- Add `icc info` command showing features, commands, hooks, MCP tools, and skills
- Surface capabilities in session startup context
- Add contextual tips to status line

### Console Improvements
- Add SSE heartbeat for web console live feed
- Add MCP broadcast support

## Test plan
- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] `go build ./cmd/icc/` succeeds
- [ ] `icc check` displays dependency status table
- [ ] `icc check --json` outputs valid JSON array
- [ ] `icc check` returns exit code 1 with missing required deps
- [ ] `icc info` lists all capabilities including `icc check`
- [ ] `icc run` warns on missing optional deps at startup