### PR TITLE
feat: enforce itkdev-code-review skill for code review requests

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -21,6 +21,7 @@ import (
 )
 
 var issueFlag string
+var reviewFlag string
 
 var runCmd = &cobra.Command{
 	Use:   "run",
@@ -119,7 +120,7 @@ background goroutine for the lifetime of the session.`,
 		}
 
 		// Build environment for Claude Code
-		env := session.BuildEnv(sessionID, actualPort, issueFlag)
+		env := session.BuildEnv(sessionID, actualPort, issueFlag, reviewFlag)
 
 		// Launch Claude Code
 		claudeArgs := session.BuildClaudeArgs()
@@ -296,5 +297,6 @@ func autoInstallIfNeeded(logger *slog.Logger) error {
 
 func init() {
 	runCmd.Flags().StringVar(&issueFlag, "issue", "", "GitHub issue number to work on (sets ICC_ISSUE_ID)")
+	runCmd.Flags().StringVar(&reviewFlag, "review", "", "PR number or branch to review (sets ICC_REVIEW_ID)")
 	rootCmd.AddCommand(runCmd)
 }

--- a/internal/hooks/code_review.go
+++ b/internal/hooks/code_review.go
@@ -1,0 +1,132 @@
+package hooks
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/itk-dev/itkdev-claude-code/internal/config"
+)
+
+func init() {
+	Register("code-review", codeReviewHook)
+}
+
+// codeReviewPattern matches common ways users ask for code reviews.
+// Examples: "review my code", "code review", "review this PR", "PR review",
+// "check my changes", "look at this PR", "examine the code"
+var codeReviewPattern = regexp.MustCompile(
+	`(?i)(?:review(?:\s+(?:my|the|this)\s+)?(?:code|changes|pull\s*request|pr)|` +
+		`code\s*review|` +
+		`(?:pull\s*request|pr)\s*review|` +
+		`(?:check|look\s+at|examine)\s+(?:(?:this|my|the)\s+)?(?:code|changes|pr))`)
+
+// codeReviewPlugin is the required plugin for the code review skill.
+var codeReviewPlugin = config.RequiredPlugin{
+	Name:        "itkdev-tools",
+	Marketplace: "itkdev-marketplace",
+}
+
+// codeReviewHook enforces the itkdev-code-review skill when users request
+// code reviews. It handles two events:
+//   - UserPromptSubmit: detects review-related prompts and injects a directive
+//     to use the itkdev-code-review skill
+//   - SessionStart: checks for ICC_REVIEW_ID env var and injects review context
+func codeReviewHook(input *Input) error {
+	switch input.HookEventName {
+	case "UserPromptSubmit":
+		return codeReviewPromptSubmit(input)
+	case "SessionStart":
+		return codeReviewSessionStart(input)
+	default:
+		ExitOK()
+		return nil
+	}
+}
+
+// codeReviewPromptSubmit checks if the user's prompt mentions a code review
+// and injects guidance to use the itkdev-code-review skill.
+func codeReviewPromptSubmit(input *Input) error {
+	prompt := strings.TrimSpace(input.Prompt)
+	if prompt == "" {
+		ExitOK()
+		return nil
+	}
+
+	if !codeReviewPattern.MatchString(prompt) {
+		ExitOK()
+		return nil
+	}
+
+	if msg := codeReviewPluginMissing(); msg != "" {
+		WriteOutput(&Output{
+			HookSpecific: &HookSpecificOuput{
+				HookEventName:     "UserPromptSubmit",
+				AdditionalContext: msg,
+			},
+		})
+		return nil
+	}
+
+	WriteOutput(&Output{
+		HookSpecific: &HookSpecificOuput{
+			HookEventName: "UserPromptSubmit",
+			AdditionalContext: "The user wants a code review. " +
+				"You MUST use the itkdev-code-review skill to handle this request. " +
+				"Invoke it with: Skill(itkdev-tools:itkdev-code-review). " +
+				"Do NOT perform a manual code review — always delegate to the skill.",
+		},
+	})
+	return nil
+}
+
+// codeReviewSessionStart checks if ICC_REVIEW_ID is set and injects
+// review context at session start.
+func codeReviewSessionStart(_ *Input) error {
+	reviewID := os.Getenv(config.EnvPrefix + "_REVIEW_ID")
+	if reviewID == "" {
+		ExitOK()
+		return nil
+	}
+
+	if msg := codeReviewPluginMissing(); msg != "" {
+		WriteOutput(&Output{
+			HookSpecific: &HookSpecificOuput{
+				HookEventName:     "SessionStart",
+				AdditionalContext: msg,
+			},
+		})
+		return nil
+	}
+
+	WriteOutput(&Output{
+		HookSpecific: &HookSpecificOuput{
+			HookEventName: "SessionStart",
+			AdditionalContext: "This session was started to review " + reviewID + ". " +
+				"You MUST use the itkdev-code-review skill to perform the review. " +
+				"Invoke it with: Skill(itkdev-tools:itkdev-code-review). " +
+				"The target to review is: " + reviewID + ". " +
+				"Do NOT perform a manual code review — always delegate to the skill.",
+		},
+	})
+	return nil
+}
+
+// codeReviewPluginMissing returns an instruction message if the required plugin
+// is not installed. Returns empty string if the plugin is available.
+func codeReviewPluginMissing() string {
+	installed, err := config.IsPluginInstalled(codeReviewPlugin)
+	if err != nil {
+		// Can't determine status — assume available to avoid blocking work.
+		return ""
+	}
+	if installed {
+		return ""
+	}
+	return "The itkdev-code-review skill requires the itkdev-tools plugin, " +
+		"which is not currently installed. " +
+		"Tell the user to install it in Claude Code with:\n" +
+		"  /plugin marketplace add itk-dev/itkdev-claude-plugins\n" +
+		"  /plugin install itkdev-tools@itkdev-marketplace\n" +
+		"Then retry this request."
+}

--- a/internal/hooks/code_review_test.go
+++ b/internal/hooks/code_review_test.go
@@ -1,0 +1,74 @@
+package hooks
+
+import "testing"
+
+func TestCodeReviewPatternMatching(t *testing.T) {
+	tests := []struct {
+		prompt string
+		want   bool
+	}{
+		// Should match — direct review requests
+		{"review my code", true},
+		{"review the code", true},
+		{"review this code", true},
+		{"review my changes", true},
+		{"review the changes", true},
+		{"review this PR", true},
+		{"review my pull request", true},
+		{"code review", true},
+		{"do a code review", true},
+		{"pull request review", true},
+		{"PR review", true},
+		{"pr review", true},
+		{"Code Review please", true},
+
+		// Should match — indirect review requests
+		{"check my code", true},
+		{"check this PR", true},
+		{"look at my changes", true},
+		{"look at this code", true},
+		{"examine the code", true},
+		{"examine my changes", true},
+
+		// Should match — mixed case
+		{"Review My Code", true},
+		{"CODE REVIEW", true},
+		{"Check My Changes", true},
+
+		// Should match — embedded in longer prompts
+		{"Can you review my code please?", true},
+		{"I'd like a code review of the latest changes", true},
+		{"Please look at my changes and give feedback", true},
+
+		// Should NOT match — unrelated prompts
+		{"hello", false},
+		{"build the project", false},
+		{"run the tests", false},
+		{"review the documentation structure", false},
+		{"fix the bug", false},
+		{"add a new feature", false},
+		{"refactor the code", false},
+		{"", false},
+
+		// Should NOT match — partial/ambiguous
+		{"review", false},
+		{"check the logs", false},
+		{"look at the database", false},
+		{"examine the architecture", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prompt, func(t *testing.T) {
+			got := codeReviewPattern.MatchString(tt.prompt)
+			if got != tt.want {
+				t.Errorf("codeReviewPattern.MatchString(%q) = %v, want %v", tt.prompt, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodeReviewHookRegistered(t *testing.T) {
+	_, ok := registry["code-review"]
+	if !ok {
+		t.Error("code-review hook not registered")
+	}
+}

--- a/internal/installer/steps/config_files.go
+++ b/internal/installer/steps/config_files.go
@@ -112,6 +112,7 @@ func settingsJSON(binPath string) []byte {
 				"Skill(spec-implement)",
 				"Skill(spec-verify)",
 				"Skill(itkdev-tools:itkdev-issue-workflow)",
+				"Skill(itkdev-tools:itkdev-code-review)",
 				"LSP",
 			},
 			"deny": []string{},
@@ -292,6 +293,15 @@ func hooksConfig(binPath string) map[string]any {
 					},
 				},
 			},
+			{
+				"hooks": []map[string]any{
+					{
+						"type":    "command",
+						"command": binPath + " hook code-review",
+						"timeout": 15,
+					},
+				},
+			},
 		},
 		"UserPromptSubmit": []map[string]any{
 			{
@@ -299,6 +309,15 @@ func hooksConfig(binPath string) map[string]any {
 					{
 						"type":    "command",
 						"command": binPath + " hook issue-workflow",
+						"timeout": 15,
+					},
+				},
+			},
+			{
+				"hooks": []map[string]any{
+					{
+						"type":    "command",
+						"command": binPath + " hook code-review",
 						"timeout": 15,
 					},
 				},

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -65,7 +65,9 @@ func ReadContextPercentage(sessionDir string) (float64, error) {
 // launching Claude Code. It inherits the current process environment and
 // adds/overrides session-specific variables. Optional issueID sets
 // ICC_ISSUE_ID when launching a session for a specific GitHub issue.
-func BuildEnv(sessionID string, port int, issueID string) []string {
+// Optional reviewID sets ICC_REVIEW_ID when launching a session for a
+// code review.
+func BuildEnv(sessionID string, port int, issueID string, reviewID string) []string {
 	env := os.Environ()
 	env = setEnv(env, config.EnvPrefix+"_SESSION_ID", sessionID)
 	env = setEnv(env, config.EnvPrefix+"_PORT", strconv.Itoa(port))
@@ -73,6 +75,9 @@ func BuildEnv(sessionID string, port int, issueID string) []string {
 	env = setEnv(env, "CLAUDE_CODE_TASK_LIST_ID", config.BinaryName+"-"+sessionID)
 	if issueID != "" {
 		env = setEnv(env, config.EnvPrefix+"_ISSUE_ID", issueID)
+	}
+	if reviewID != "" {
+		env = setEnv(env, config.EnvPrefix+"_REVIEW_ID", reviewID)
 	}
 	return env
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -79,7 +79,7 @@ func TestReadContextPercentageMissing(t *testing.T) {
 }
 
 func TestBuildEnv(t *testing.T) {
-	env := BuildEnv("test-session-123", 41777, "")
+	env := BuildEnv("test-session-123", 41777, "", "")
 
 	found := map[string]string{}
 	for _, e := range env {

--- a/internal/session/runner_test.go
+++ b/internal/session/runner_test.go
@@ -28,7 +28,7 @@ func TestBuildClaudeArgs(t *testing.T) {
 }
 
 func TestBuildEnvSetsAllRequired(t *testing.T) {
-	env := BuildEnv("test-123", 41777, "")
+	env := BuildEnv("test-123", 41777, "", "")
 
 	required := map[string]bool{
 		"ICC_SESSION_ID":           false,


### PR DESCRIPTION
## Summary
- Adds a `code-review` hook that detects code review requests via regex pattern matching on `UserPromptSubmit` and injects `AdditionalContext` directing Claude to use the `itkdev-code-review` skill
- Adds `--review` CLI flag to `icc run` (sets `ICC_REVIEW_ID` env var) for explicit activation via `SessionStart`
- Registers the hook in `SessionStart` and `UserPromptSubmit` events, and adds `Skill(itkdev-tools:itkdev-code-review)` to the permissions allow list

Closes #14

## Test plan
- [x] Pattern matching tests pass (37 cases: positive, negative, mixed case, embedded prompts)
- [x] Hook registration verified
- [x] All existing tests pass (`go test ./...`)
- [x] Binary builds successfully (`make build`)
- [ ] Manual test: `icc run --review pr-123` injects review context at session start
- [ ] Manual test: typing "review my code" triggers skill directive
- [ ] Manual test: "review the documentation structure" does NOT trigger